### PR TITLE
Add promise finally shim to make LayerManager work with Firefox

### DIFF
--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -13,6 +13,10 @@ import { Icons } from 'vizzuality-components'
 import { ThemeProvider } from 'react-jss'
 import styleVariables from './styles/variables'
 
+// Fix LayerManager-Firefox compatability issue
+import promiseFinally from 'promise.prototype.finally'
+promiseFinally.shim()
+
 const App = ({ layers, pages }) => {
   const globalStyles = {
     font: `14px/16px ${styleVariables().fonts.body}`,
@@ -31,6 +35,7 @@ const App = ({ layers, pages }) => {
       />
     )
   )
+
 
   return (
     <ThemeProvider theme={globalStyles}>

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "layer-manager": "^1.15.2",
     "moment": "^2.24.0",
     "numeral": "^2.0.6",
+    "promise.prototype.finally": "^3.1.1",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
@@ -54,6 +55,7 @@
     ]
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "dev": "foreman start -f Procfile.dev"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7817,6 +7817,15 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
+promise.prototype.finally@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/promise.prototype.finally/-/promise.prototype.finally-3.1.1.tgz#cb279d3a5020ca6403b3d92357f8e22d50ed92aa"
+  integrity sha512-gnt8tThx0heJoI3Ms8a/JdkYBVhYP/wv+T7yQimR+kdOEJL21xTFbiJhMRqnSPcr54UVvMbsscDk2w+ivyaLPw==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.13.0"
+    function-bind "^1.1.1"
+
 prompts@^2.0.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.2.1.tgz#f901dd2a2dfee080359c0e20059b24188d75ad35"


### PR DESCRIPTION
Copied the following commit from Vizz's resource watch app:
https://github.com/resource-watch/resource-watch/commit/adbba8a414d5416ee0bfb65adc1aeb4c4fd99ba3

Closes #81 
Closes #82 
(82 was already addressed in PR #83 but I messed up the issue linking) 