### PR TITLE
Add puma restart to deploy script

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -51,3 +51,5 @@ end
 
 before 'deploy', 'gr:last_revision'
 after 'deploy:log_revision', :push_deploy_tag
+
+after 'deploy:finished', 'puma:restart'

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -54,4 +54,13 @@ end
 before 'deploy', 'gr:last_revision'
 after 'deploy:log_revision', :push_deploy_tag
 
-after 'deploy:finished', 'puma:restart'
+desc 'Restart puma to pick up latest code changes'
+task :restart_puma do
+  ruby_version = File.read(".ruby-version").chomp.split("-").last
+
+  on roles(:app) do
+    execute "bash -l -c 'cd #{fetch(:release_path)} && rvm #{ruby_version} do bundle exec pumactl -S #{fetch(:deploy_to)}/shared/tmp/pids/puma.state -F #{fetch(:deploy_to)}/shared/puma.rb restart'"
+  end
+end
+
+after 'deploy', :restart_puma

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,3 +1,5 @@
+require "tzinfo"
+
 # config valid for current version and patch releases of Capistrano
 lock '~> 3.16.0'
 
@@ -36,7 +38,7 @@ end
 
 desc 'Tag the deployed revision'
 task :push_deploy_tag do
-  on roles(:util) do
+  on roles(:app) do
     env = fetch(:rails_env)
     timestamp = fetch(:release_timestamp) || Time.now.utc.strftime('%Y%m%d%H%M')
 


### PR DESCRIPTION
@yakloinsteak this didn't work because "puma:restart" is not a thing (despite some post I read on the internet). I'm also realizing when we do the restart we need sudo privileges:
![image](https://user-images.githubusercontent.com/294776/153934853-21356983-a4f8-4018-9cb3-d84f81ba6b0d.png)

Do you think this is worth pursuing or should we just do manual restarts since we don't deploy to WRI that often anyway? (They're in maintenance mode now)