### PR TITLE
Wpsi 39 add consistency to the team tags colors

### DIFF
--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -2,7 +2,7 @@ class Admin::TagsController < Admin::BaseController
   before_action :set_tag, only: %i[show edit update destroy]
 
   def index
-    @tags = Tag.all
+    @tags = Tag.ordered_by_name
   end
 
   def new
@@ -47,7 +47,8 @@ class Admin::TagsController < Admin::BaseController
 
   def tag_params
     params.require(:tag).permit(
-      :name
+      :name,
+      :tag_color
     ).to_h
   end
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,2 +1,3 @@
 class Tag < ApplicationRecord
+  scope :ordered_by_name, -> { order(name: :asc) }
 end

--- a/app/views/admin/shared/_navbar.html.slim
+++ b/app/views/admin/shared/_navbar.html.slim
@@ -23,6 +23,8 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-light.mb-4
           = link_to 'Events', admin_events_path, class: 'nav-link'
         li.nav-item class=('active' if current_controller == 'team_members')
           = link_to 'Team Members', admin_team_members_path, class: 'nav-link'
+        li.nav-item class=('active' if current_controller == 'tags')
+          = link_to 'Tags', admin_tags_path, class: 'nav-link'
         li.nav-item class=('active' if current_controller == 'news_items')
           = link_to 'News Items', admin_news_items_path, class: 'nav-link'
         li.nav-item class=('active' if current_controller == 'users')

--- a/app/views/admin/tags/_form.html.slim
+++ b/app/views/admin/tags/_form.html.slim
@@ -5,5 +5,9 @@
     .field
       = f.label :name
       = f.text_field :name, class: 'form-control'
+
+    .field
+      = f.label :tag_color
+      = f.color_field :tag_color, class: 'form-control', style: "padding: 0px;"
   
   .actions = f.submit class: 'btn btn-primary'

--- a/app/views/admin/tags/index.html.slim
+++ b/app/views/admin/tags/index.html.slim
@@ -10,6 +10,8 @@ table.table
     - @tags.each do |tag|
       tr
         td = tag.name
+
+        td style="background-color: #{tag.tag_color};" = tag.tag_color
           
         td 
           => link_to 'Edit', edit_admin_tag_path(tag)

--- a/app/views/admin/team_members/_form.html.slim
+++ b/app/views/admin/team_members/_form.html.slim
@@ -28,7 +28,7 @@
     .field
       = f.label :tags
       .p-3.tag-checkboxes.rounded
-        = collection_check_boxes(:tags, :tag_id, Tag.all,:id, :name, { checked: @team_member.tags.map(&:to_param) })
+        = collection_check_boxes(:tags, :tag_id, Tag.ordered_by_name,:id, :name, { checked: @team_member.tags.map(&:to_param) })
     .pt-2
       = link_to 'Manage tags', admin_tags_path,
           target: '_blank', rel: 'noopener noreferrer'

--- a/app/views/root/landing/_team_member.html.slim
+++ b/app/views/root/landing/_team_member.html.slim
@@ -16,7 +16,9 @@ ruby:
             </svg>
         = team_member.email
       .tags
-        - team_member.tags.map(&:name).each do |tag|
-          span 
-            = tag
+        - team_member.tags.each do |tag|
+          - if tag.tag_color != '#ffffff'
+            span style="background-color: #{tag.tag_color};" = tag.name
+          - else
+            span = tag.name
     .profile-image-card-section style="background-image: url(#{team_member.profile_image});"

--- a/db/migrate/20230710163945_add_tag_color.rb
+++ b/db/migrate/20230710163945_add_tag_color.rb
@@ -1,0 +1,5 @@
+class AddTagColor < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tags, :tag_color, :string, :default => '#ffffff'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_25_164055) do
+ActiveRecord::Schema.define(version: 2023_07_10_163945) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -125,6 +125,7 @@ ActiveRecord::Schema.define(version: 2023_04_25_164055) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "tag_color", default: "#ffffff"
   end
 
   create_table "team_member_tags", force: :cascade do |t|


### PR DESCRIPTION
# Tag features

### admin

- [ ] it is possible to navigate to the tags from the navbar
- [ ] while editing you can define the tag color
- [ ] tag color by default is white '#fffff'
- [ ] if tag color is white, a predetermined color is defined to the tag
- [ ] defined tag color overrides predetermined color